### PR TITLE
debug: 405 (Not Allowed)

### DIFF
--- a/Frontend/nginx.conf
+++ b/Frontend/nginx.conf
@@ -7,6 +7,14 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    location /api/ {
+        proxy_pass http://61.109.239.132:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         try_files $uri /index.html;
     }


### PR DESCRIPTION
- 에러 원인
Nginx가 /api/로 들어오는 요청을 백엔드 서버로 전달하지 않고,
정적 파일(프론트엔드 빌드 결과)만 서빙하도록 설정되어 있었습니다.
이로 인해 프론트엔드에서 백엔드로의 API 요청이 제대로 전달되지 않고,
404, 405, 또는 잘못된 응답이 발생했습니다.

- 해결 방법
Nginx 설정 파일(nginx.conf)에 /api/ 경로 프록시 설정을 추가했습니다.

    location /api/ {
        proxy_pass http://61.109.239.132:8000;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;

- 정리
Nginx에 API 프록시 설정이 없어서 발생한 문제였으며,
프록시 설정 추가로 해결되었습니다!